### PR TITLE
Clarify example

### DIFF
--- a/data/treebor/src/shared.md
+++ b/data/treebor/src/shared.md
@@ -65,11 +65,11 @@ fn reborrow_disabled(u: &mut u8) {
     *x = 42;
 
     let y = &mut *u;
-    *x = 36;
+    *y = 36;
                         // --- u: Active
                         //     |--- x: Disabled
                         //     |--- y: Active
-    let y = &*x;
+    let z = &*x;
                         // This is an attempted reborrow from `x: Disabled`.
                         // It counts as an attempted read, and `Disabled` forbids
                         // reads.


### PR DESCRIPTION
The “y” I believe is just a typo. The “z” just a stylistic change, to avoid thinking about shadowing.