### PR TITLE
Add missing `mut` to protectors optimized example

### DIFF
--- a/data/treebor/src/protectors.md
+++ b/data/treebor/src/protectors.md
@@ -134,7 +134,7 @@ fn convoluted_write(u: &mut u8) -> u8 {
 }
 
 //? Optimized
-fn convoluted_write_opt(u: &u8) -> u8 {
+fn convoluted_write_opt(u: &mut u8) -> u8 {
     opaque();
     *u = 42;
     42


### PR DESCRIPTION
I believe that this is a copy-paste error, since the example performs a write through `u`.