### PR TITLE
Fix description of `conflicted` flag semantics

### DIFF
--- a/data/treebor/src/protectors.md
+++ b/data/treebor/src/protectors.md
@@ -77,7 +77,7 @@ Detecting this takes two forms:
   this function call. We model this by adding a boolean flag `conflicted` to
   `Reserved` that is initially `false`, becomes `true` if the tag is protected
   while a foreign read occurs, and triggers UB if it is `true` while the tag is
-  still protected if we try to perform a foreign write.
+  still protected if we try to perform a child write.
 
 > <span class="sbnote">
 **[Note: Stacked Borrows]** This mostly aligns with the concept of protectors


### PR DESCRIPTION
I am trying to understand Tree Borrows, and I believe there is a typo in the description of the `conflicted` flag. I am not 100% sure but I think this is right?

In my understanding, whenever there is a foreign read on a protected `Restricted` tag, the purpose of the `conflicted` flag is to ensure that a subsequent _child_ write will trigger UB. Without the `conflicted` flag, there is no way to detect a child write as UB despite it violating `noalias` restrictions, since the foreign read doesn't otherwise affect the tag permissions in any way.